### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/core/js/scheduler.js
+++ b/src/core/js/scheduler.js
@@ -45,12 +45,12 @@ const toYearlyMoment = (date, string) => {
 
 		// if is time (at 12:00)
 		if (/^at/.test(part)) {
-			obj.time = toTime(clone(date), part.substr(3));
+			obj.time = toTime(clone(date), part.slice(3));
 		}
 
 		// is waiting period
 		else if (/wait/.test(part)) {
-			obj.idle = toInterval(part.substr(5));
+			obj.idle = toInterval(part.slice(5));
 		}
 
 		// must be month
@@ -175,12 +175,12 @@ const toMonthlyMoment = (date, string) => {
 
 		// if is time (at 12:00)
 		if (/^at/.test(part)) {
-			obj.time = toTime(clone(date), part.substr(3));
+			obj.time = toTime(clone(date), part.slice(3));
 		}
 
 		// is waiting period
 		else if (/wait/.test(part)) {
-			obj.idle = toInterval(part.substr(5));
+			obj.idle = toInterval(part.slice(5));
 		}
 
 		return obj;
@@ -304,12 +304,12 @@ const toWeeklyMoment = (date, string) => {
 
 		// if is time (at 12:00)
 		if (/^at/.test(part)) {
-			obj.time = toTime(clone(date), part.substr(3));
+			obj.time = toTime(clone(date), part.slice(3));
 		}
 
 		// is waiting period
 		else if (/wait/.test(part)) {
-			obj.idle = toInterval(part.substr(5));
+			obj.idle = toInterval(part.slice(5));
 		}
 
 		return obj;
@@ -391,7 +391,7 @@ const toDailyMoment = (date, string) => {
 
 		// is waiting period
 		else if (/wait/.test(part)) {
-			obj.idle = toInterval(part.substr(5));
+			obj.idle = toInterval(part.slice(5));
 		}
 
 		return obj;
@@ -448,7 +448,7 @@ const toHourlyMoment = (date, string) => {
 
 		// is waiting period
 		else if (/wait/.test(part)) {
-			obj.idle = toInterval(part.substr(5));
+			obj.idle = toInterval(part.slice(5));
 		}
 
 		// if is interval

--- a/src/core/js/style.js
+++ b/src/core/js/style.js
@@ -87,7 +87,7 @@ const toTransitionPartial = (string) => {
  */
 const toGradient = (string) => {
 	const type = string.match(/follow-gradient|horizontal-gradient|vertical-gradient/)[0];
-	const colors = string.substr(type.length).match(/(?:transparent|rgb\(.*?\)|hsl\(.*?\)|hsla\(.*?\)|rgba\(.*?\)|[a-z]+|#[abcdefABCDEF\d]+)\s?(?:[\d]{1,3}%?)?/g).map(toGradientColor);
+	const colors = string.slice(type.length).match(/(?:transparent|rgb\(.*?\)|hsl\(.*?\)|hsla\(.*?\)|rgba\(.*?\)|[a-z]+|#[abcdefABCDEF\d]+)\s?(?:[\d]{1,3}%?)?/g).map(toGradientColor);
 	return {
 		type,
 		colors


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.