### PR TITLE
Fixed bug with incorrect countdown being shown.

### DIFF
--- a/src/core/js/timer.js
+++ b/src/core/js/timer.js
@@ -67,6 +67,9 @@ export const setTimer = (cb, interval = 1000, options = {}) => {
 			cb(0);
 		}, 0);
 
+		// the moment the timeout should end
+		tickExpectedTime = now() + interval;
+
 		// listen for changes in visibility
 		startListeningForVisibilityChanges();
 		
@@ -75,9 +78,6 @@ export const setTimer = (cb, interval = 1000, options = {}) => {
 			didHideDocument();
 			return;
 		}
-		
-		// the moment the timeout should end
-		tickExpectedTime = now() + interval;
 		
 		// start ticking
 		timer = setTimeout(() => {


### PR DESCRIPTION
Occurs when a user types in the URL of a page that has a flip on it and that URL is one that has already been visited before. Chrome (and possibly other) browsers pre-render the page as part of their URL suggestion logic. This background pre-rendering would cause flip to immediately sleep() before calculating tickExpectedTime.

Fixes https://github.com/pqina/flip/issues/50